### PR TITLE
Needed some changes to get it running with a homebrew installation of liquibase

### DIFF
--- a/cmd/lpm/darwin.go
+++ b/cmd/lpm/darwin.go
@@ -32,7 +32,7 @@ func main() {
 		}
 
 		if fi.Mode()&os.ModeSymlink != 0 {
-			link, err := os.Readlink(loc)
+			link, err := filepath.EvalSymlinks(loc)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -43,7 +43,10 @@ func main() {
 			liquibasehome, _ = filepath.Split(loc)
 		}
 	}
-
+	//handles homebrew installation of liquibase
+	if strings.Contains(liquibasehome, "Cellar") {
+		liquibasehome = strings.Replace(liquibasehome, "/bin", "/libexec", 1)
+	}
 	if !strings.HasSuffix(liquibasehome, "/") {
 		liquibasehome = liquibasehome + "/"
 	}


### PR DESCRIPTION
## Issues Addressed

Fixes maybe an issue running lpm commands with liquibase installed via homebrew. 

Running lpm on osx Big Sur v11.4 with liquibase v4.4.0 installed via homebrew I found the error: 

```
$ go run darwin.go add db2
open ../Cellar/liquibase/4.4.0/bin/lib/: no such file or directory
exit status 1
```

## Proposed Changes

First I thought it was only an issue with the path, so I changed the symlink search to use `filepath.EvalSymlinks` which resolves to the proper location. Then I found that homebrew always installs extras into a folder `libexec` which is outside of `bin`. [See here for more, I had no idea.](https://apple.stackexchange.com/a/277658)

## Testing

Golang newbie here. I'm not sure how to begin testing this 👀. Let me know what action I should take.